### PR TITLE
added message frame to messages

### DIFF
--- a/src/consolidator/schema_merger.py
+++ b/src/consolidator/schema_merger.py
@@ -19,7 +19,7 @@ import asn1tools
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def merge_dependencies(schema_files, combined_deps, input_dir="data/files/schema", output_dir="data/files/schema_updated"):
+def merge_dependencies(schema_files, asn1_definitions,combined_deps, input_dir="data/files/schema", output_dir="data/files/schema_updated"):
     """
     Merges schema files with their transitive dependencies and writes the combined content to a new directory.
 
@@ -30,7 +30,7 @@ def merge_dependencies(schema_files, combined_deps, input_dir="data/files/schema
         output_dir (str): Directory to write the merged schema files.
     """
     os.makedirs(output_dir, exist_ok=True)
-
+    schema_names= [f.split(".")[0] for f in schema_files]
     for schema_file in schema_files:
         name = schema_file.split(".")[0]
         base_path = os.path.join(input_dir, schema_file)
@@ -38,13 +38,15 @@ def merge_dependencies(schema_files, combined_deps, input_dir="data/files/schema
         try:
             with open(base_path, 'r', encoding='utf-8') as f:
                 data = f.read()
-
-            
-
             for dep in combined_deps.get(name, []):
-                dep_path = os.path.join(input_dir, f"{dep}.asn1")
-                with open(dep_path, 'r', encoding='utf-8') as dep_file:
-                    data += dep_file.read()
+                if dep in schema_names:
+                    dep_path = os.path.join(input_dir, f"{dep}.asn1")
+                    with open(dep_path, 'r', encoding='utf-8') as dep_file:
+                        data += dep_file.read()
+                elif dep in asn1_definitions:
+                    dep_path = os.path.join("data/files/definitions", f"{dep}.asn1")
+                    with open(dep_path, 'r', encoding='utf-8') as dep_file:
+                        data += dep_file.read()
 
             out_path = os.path.join(output_dir, schema_file)
             with open(out_path, 'w', encoding='utf-8') as out_file:
@@ -72,7 +74,7 @@ def wrap_definitions(schema_files, target_dir="data/files/schema_updated"):
            
 
             # Prepend and append definition markers
-            wrapped_lines = [f"{name} DEFINITIONS ::= BEGIN"] + lines + ["END"]
+            wrapped_lines = [f"{name} DEFINITIONS AUTOMATIC TAGS::= BEGIN"] + lines + ["END"]
 
             with open(file_path, 'w', encoding='utf-8') as file:
                 for line in wrapped_lines:
@@ -80,6 +82,42 @@ def wrap_definitions(schema_files, target_dir="data/files/schema_updated"):
 
         except Exception as e:
             logger.error(f"Failed to wrap ASN.1 definitions in {schema_file}: {e}")
+
+
+def wrap_message_frame(message_files,target_dir="data/output/messages"):
+    """
+    Wraps each message ASN.1 file in `MessageFrame ::= BEGIN ... END` block.
+
+    Args:
+        message_files (list[str]): List of message schema filenames.
+        target_dir (str): Directory containing message files.
+    """
+    for message_file in message_files:
+        file_path = os.path.join(target_dir, message_file)
+
+        try:
+            with open(file_path, 'r', encoding='utf-8') as file:
+                data=file.read()
+        
+                lines=data.splitlines()
+                new_lines=[]
+                new_lines.append(f"{message_file.split('.')[0]} DEFINITIONS AUTOMATIC TAGS ::= BEGIN")
+                new_lines.append("MessageFrame ::= SEQUENCE {")
+                new_lines.append(f"    messageId DSRCmsgID,")
+                new_lines.append(f"    value {message_file.split('.')[0]}")
+                new_lines.append("}\n")
+
+                new_lines.append("DSRCmsgID ::= INTEGER (0..32767)\n")
+
+                for line in lines[1:]:
+                    new_lines.append(line)
+
+
+            with open(file_path, 'w', encoding='utf-8') as file:
+                file.write('\n'.join(new_lines))
+
+        except Exception as e:
+            logger.error(f"Failed to wrap MessageFrame in {message_file}: {e}")
 
 def verify_syntax(schema_files, target_dir="data/files/schema_updated", error_log_path="error_files.json"):
     """

--- a/src/dependency_resolver/resolver.py
+++ b/src/dependency_resolver/resolver.py
@@ -29,7 +29,7 @@ def clean_string(s):
     """
     return re.sub(r'[^a-zA-Z0-9-]', '', s)
 
-def build_dependency_matrix(schema_files, schema_names, schema_dir="data/files/schema"):
+def build_dependency_matrix(schema_files, asn1_definitions,schema_names, schema_dir="data/files/schema"):
     """
     Parses ASN.1 schema files to build a direct dependency matrix.
 
@@ -44,7 +44,6 @@ def build_dependency_matrix(schema_files, schema_names, schema_dir="data/files/s
         dict: A mapping from each schema name to a list of its direct dependencies.
     """
     dependency_matrix = {}
-
     for schema_file in schema_files:
         dependencies = set()
         name = schema_file.split(".")[0]
@@ -79,11 +78,14 @@ def build_dependency_matrix(schema_files, schema_names, schema_dir="data/files/s
 
                 word = clean_string(word)
 
+                if word in asn1_definitions and word != name:
+                    dependencies.add(word)
+
                 # If a word matches another schema component and is not self-reference
                 if word in schema_names and word != name:
                     dependencies.add(word)
 
-        dependency_matrix[name] = sorted(list(dependencies))
+        dependency_matrix[name] = list(dependencies)
         # logger.debug(f"Dependencies for {name}: {dependency_matrix[name]}")
 
     return dependency_matrix

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ import os
 from src.parser.component_extractor import extract_components, remove_namespace_references
 from src.parser.namespace_extractor import extract_namespaces, write_namespace_files
 from src.validation.file_validator import  validate_file
-from src.consolidator.schema_merger import copy_message_deps, merge_dependencies, verify_syntax, wrap_definitions
+from src.consolidator.schema_merger import copy_message_deps, merge_dependencies, verify_syntax, wrap_definitions, wrap_message_frame
 from src.dependency_resolver.resolver import build_dependency_matrix, resolve_dependencies
 
 import os
@@ -28,7 +28,8 @@ def ensure_data_directories():
     required_dirs = [
         "data/output",
         "data/files/namespace",
-        "data/files/schema"
+        "data/files/schema",
+        "data/files/definitions",
     ]
 
     input_dir=[
@@ -40,6 +41,7 @@ def ensure_data_directories():
         os.remove("./error_files.json")
 
     for path in required_dirs:
+        print(path)
         # empty folders before starting
         if os.path.exists(path) and os.path.isdir(path):
             for file in os.listdir(path):
@@ -100,24 +102,34 @@ if __name__ == "__main__":
     remove_namespace_references(schema_files, list(namespaces))
 
     # Step 4: Build dependency matrix and resolve transitive dependencies
+    asn1_definitions_files= os.listdir("data/files/definitions")
+    asn1_definitions= [i.split(".")[0] for i in asn1_definitions_files]
+
+
     print("\n Step 4: Building and resolving dependency graph...")
-    deps = build_dependency_matrix(schema_files, schema_names)
+    deps = build_dependency_matrix(schema_files, asn1_definitions,schema_names)
     combined_deps = resolve_dependencies(deps)
 
     # Step 5: Merge dependencies and wrap each schema in ASN.1 definition blocks
     print("\n Step 5: Merging dependencies and wrapping schema definitions...")
-    merge_dependencies(schema_files, combined_deps)
+    merge_dependencies(schema_files, asn1_definitions,combined_deps)
     wrap_definitions(schema_files)
+
+    copy_message_deps(deps)
+
+    message_files = os.listdir("data/output/messages")
+    wrap_message_frame(message_files)
+
 
     # Step 6: Verify ASN.1 syntax and structure
     print("\n Step 6: Verifying ASN.1 syntax and structure...")
 
     # Step 7: Copy required message types
     print("\n Step 7: Copying final message types to output folder...")
-    res=verify_syntax(schema_files)
+    res=verify_syntax(message_files)
     if res > 0:
         print(f"  {res} errors found in schema files.")
     
-    copy_message_deps(deps)
+   
 
     print("\n  ASN.1 processing completed successfully! Check data/output/messages")

--- a/src/parser/component_extractor.py
+++ b/src/parser/component_extractor.py
@@ -77,11 +77,16 @@ def extract_components(namespace_files, input_dir="data/files/namespace", output
 
         # Write each top-level component to its own file
         for comp_name in components:
-            if comp_name[0].islower():
-                continue  # Skip components starting with lowercase (often private/internal)
-
             safe_name = sanitize_filename(comp_name)
             output_path = os.path.join(output_dir, f"{safe_name}.asn1")
+
+            if comp_name[0].islower():
+                output_definition_path= os.path.join("data/files/definitions", f"{safe_name}.asn1")
+                # print(f"Writing component '{comp_name}' to: {output_definition_path}")
+                with open(output_definition_path,'w') as f:
+                        for j in range(components[comp_name]["start"] - 1, components[comp_name]["end"]):
+                            f.write(lines[j] + '\n')
+                continue
 
             try:
                 with open(output_path, 'w') as file:

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -7,25 +7,22 @@ from dependency_resolver.resolver import clean_string, build_dependency_matrix, 
 
 @pytest.fixture(scope="module")
 def setup_temp_schema_files():
-    """
-    Creates a temporary test directory with dummy ASN.1 schema files.
-    """
     temp_schema_dir = "temp_test_schemas"
     os.makedirs(temp_schema_dir, exist_ok=True)
 
     schemas = {
         "Position3D.asn1": "Position3D ::= SEQUENCE { x INTEGER, y INTEGER }",
-        "MessageFrame.asn1": "MessageFrame ::= SEQUENCE { pos Position3D }",
+        "MessageFrame.asn1": "MessageFrame ::= SEQUENCE { pos Position3D, msgId DSRCmsgID }",  
         "VehicleStatus.asn1": "VehicleStatus ::= SEQUENCE { speed INTEGER, loc Position3D }",
+        "DSRCmsgID.asn1": "DSRCmsgID ::= INTEGER (0..32767)"
     }
 
     for filename, content in schemas.items():
         with open(os.path.join(temp_schema_dir, filename), "w") as f:
             f.write(content)
 
-    yield temp_schema_dir  # Provide the directory path to the test functions
+    yield temp_schema_dir
 
-    # Cleanup after tests
     shutil.rmtree(temp_schema_dir)
 
 def test_clean_string():
@@ -39,16 +36,19 @@ def test_build_dependency_matrix(setup_temp_schema_files):
     schema_dir = setup_temp_schema_files
     schema_files = ["Position3D.asn1", "MessageFrame.asn1", "VehicleStatus.asn1"]
     schema_names = [f.split(".")[0] for f in schema_files]
+    asn1_definitions = {"DSRCmsgID": True}
 
-    dependency_matrix = build_dependency_matrix(schema_files, schema_names, schema_dir=schema_dir)
+    dependency_matrix = build_dependency_matrix(schema_files, asn1_definitions, schema_names, schema_dir=schema_dir)
 
     expected = {
         "Position3D": [],
-        "MessageFrame": ["Position3D"],
+        "MessageFrame": ["Position3D", "DSRCmsgID"],
         "VehicleStatus": ["Position3D"]
     }
 
-    assert dependency_matrix == expected
+    assert set(dependency_matrix["MessageFrame"]) == {"Position3D", "DSRCmsgID"}
+    assert dependency_matrix["Position3D"] == []
+    assert dependency_matrix["VehicleStatus"] == ["Position3D"]
 
 def test_resolve_dependencies():
     direct_deps = {

--- a/tests/test_schema_merger.py
+++ b/tests/test_schema_merger.py
@@ -19,36 +19,42 @@ def setup_temp_schema_dirs():
     input_dir = "temp_schema_input"
     output_dir = "temp_schema_output"
     messages_dir = os.path.join(output_dir, "messages")
-
+    definitions_dir = os.path.join("data", "files", "definitions")
     os.makedirs(input_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(messages_dir, exist_ok=True)
+    os.makedirs(definitions_dir, exist_ok=True)
 
     # Create some dummy schema files
     schemas = {
         "Position3D.asn1": "Position3D ::= SEQUENCE { x INTEGER, y INTEGER }",
-        "MessageFrame.asn1": "MessageFrame ::= SEQUENCE { pos Position3D }",
+        "MessageFrame.asn1": "MessageFrame ::= SEQUENCE { pos Position3D, msgId DSRCmsgID }",
     }
-
     for filename, content in schemas.items():
         with open(os.path.join(input_dir, filename), "w") as f:
             f.write(content)
 
-    yield input_dir, output_dir, messages_dir
+    # Create a dummy definition file in definitions_dir
+    with open(os.path.join(definitions_dir, "DSRCmsgID.asn1"), "w") as f:
+        f.write("DSRCmsgID ::= INTEGER (0..32767)")
+
+    yield input_dir, output_dir, messages_dir, definitions_dir
 
     # Cleanup after tests
     shutil.rmtree(input_dir)
     shutil.rmtree(output_dir)
+    shutil.rmtree(definitions_dir, ignore_errors=True)
 
 def test_merge_dependencies(setup_temp_schema_dirs):
-    input_dir, output_dir, _ = setup_temp_schema_dirs
+    input_dir, output_dir, _, _ = setup_temp_schema_dirs
 
-    schema_files = ["MessageFrame.asn1"]
+    # Pass both files so the dependency logic works!
+    schema_files = ["MessageFrame.asn1", "Position3D.asn1"]
     combined_deps = {
         "MessageFrame": ["Position3D"]
     }
 
-    merge_dependencies(schema_files, combined_deps, input_dir=input_dir, output_dir=output_dir)
+    merge_dependencies(schema_files, {}, combined_deps, input_dir=input_dir, output_dir=output_dir)
 
     output_file = os.path.join(output_dir, "MessageFrame.asn1")
     assert os.path.exists(output_file)
@@ -56,36 +62,73 @@ def test_merge_dependencies(setup_temp_schema_dirs):
     with open(output_file, "r") as f:
         merged_content = f.read()
 
-    # Should contain content from both MessageFrame and Position3D
     assert "MessageFrame ::=" in merged_content
     assert "Position3D ::=" in merged_content
 
-def test_wrap_definitions(setup_temp_schema_dirs):
-    _, output_dir, _ = setup_temp_schema_dirs
+def test_merge_dependencies_with_asn1_definitions(setup_temp_schema_dirs):
+    input_dir, output_dir, _, definitions_dir = setup_temp_schema_dirs
 
-    schema_files = ["MessageFrame.asn1"]
-    wrap_definitions(schema_files, target_dir=output_dir)
+    schema_files = ["MessageFrame.asn1", "Position3D.asn1"]
+    asn1_definitions = {"DSRCmsgID": True}
+    combined_deps = {
+        "MessageFrame": ["Position3D", "DSRCmsgID"]
+    }
+
+    merge_dependencies(schema_files, asn1_definitions, combined_deps, input_dir=input_dir, output_dir=output_dir)
+
+    output_file = os.path.join(output_dir, "MessageFrame.asn1")
+    assert os.path.exists(output_file)
+
+    with open(output_file, "r") as f:
+        merged_content = f.read()
+
+    assert "MessageFrame ::=" in merged_content
+    assert "Position3D ::=" in merged_content
+    assert "DSRCmsgID ::=" in merged_content
+
+def test_wrap_definitions(setup_temp_schema_dirs):
+    input_dir, output_dir, _, _ = setup_temp_schema_dirs
+
+    schema_files = ["MessageFrame.asn1", "Position3D.asn1"]
+    combined_deps = {
+        "MessageFrame": ["Position3D"]
+    }
+    merge_dependencies(schema_files, {}, combined_deps, input_dir=input_dir, output_dir=output_dir)
+
+    wrap_definitions(["MessageFrame.asn1"], target_dir=output_dir)
 
     output_file = os.path.join(output_dir, "MessageFrame.asn1")
     with open(output_file, "r") as f:
         content = f.read()
 
-    assert "MessageFrame DEFINITIONS ::= BEGIN" in content
+    assert "MessageFrame DEFINITIONS AUTOMATIC TAGS::= BEGIN" in content or \
+           "MessageFrame DEFINITIONS ::= BEGIN" in content
     assert content.strip().endswith("END")
 
 def test_verify_syntax(setup_temp_schema_dirs):
-    _, output_dir, _ = setup_temp_schema_dirs
+    input_dir, output_dir, _, _ = setup_temp_schema_dirs
 
-    schema_files = ["MessageFrame.asn1"]
+    schema_files = ["MessageFrame.asn1", "Position3D.asn1"]
+    combined_deps = {
+        "MessageFrame": ["Position3D"]
+    }
+    merge_dependencies(schema_files, {}, combined_deps, input_dir=input_dir, output_dir=output_dir)
+    wrap_definitions(["MessageFrame.asn1"], target_dir=output_dir)
+
     error_log_path = os.path.join(output_dir, "errors.json")
+    verify_syntax(["MessageFrame.asn1"], target_dir=output_dir, error_log_path=error_log_path)
 
-    verify_syntax(schema_files, target_dir=output_dir, error_log_path=error_log_path)
-
-    # Should not create an error log if syntax is good
     assert not os.path.exists(error_log_path)
 
 def test_copy_message_deps(setup_temp_schema_dirs):
-    _, output_dir, messages_dir = setup_temp_schema_dirs
+    input_dir, output_dir, messages_dir, _ = setup_temp_schema_dirs
+
+    schema_files = ["MessageFrame.asn1", "Position3D.asn1"]
+    combined_deps = {
+        "MessageFrame": ["Position3D"]
+    }
+    merge_dependencies(schema_files, {}, combined_deps, input_dir=input_dir, output_dir=output_dir)
+    wrap_definitions(["MessageFrame.asn1"], target_dir=output_dir)
 
     deps = {
         "MessageTypes": ["MessageFrame"]
@@ -95,3 +138,5 @@ def test_copy_message_deps(setup_temp_schema_dirs):
 
     copied_file = os.path.join(messages_dir, "MessageFrame.asn1")
     assert os.path.exists(copied_file)
+
+


### PR DESCRIPTION
Added message frame to individual spec files

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Updated ASN1 Spec Splitter to include MessageFrame as dependency and did some minor fixes

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

ARC-414

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

validated by running the exisiting validate_asn1_messages.py script

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
